### PR TITLE
docs: Trim the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 The official documentation for the [Pidgin Wiki](https://github.com/PidginWiki) project,
 published at [docs.pidgin.wiki](https://docs.pidgin.wiki).
 
-Built with [Astro Starlight](https://starlight.astro.build/).
-
 ## Develop
 
 ```sh
@@ -14,23 +12,8 @@ pnpm build      # production build to ./dist
 pnpm preview    # preview the production build
 ```
 
-If `pnpm build` reports ignored build scripts, run the build directly with
-`pnpm exec astro build`; the native dependencies are optional and the build succeeds
-without them.
-
-## Structure
-
-Content lives in `src/content/docs`:
-
-- `introduction.md` — project overview and goals
-- `architecture/` — Bandolo, Langwa, Pidgin.Wiki, and the overview
-- `project/` — requirements (SRS), roadmap, data governance and licensing
-- `contribute/` — how to contribute
-
-## Deploy
-
-Pushing to `master` triggers the GitHub Pages workflow in
-`.github/workflows/deploy.yml`. The custom domain is set via `public/CNAME`.
+If `pnpm build` reports ignored build scripts, run it directly with
+`pnpm exec astro build`.
 
 ## License
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,7 +14,6 @@ export default defineConfig({
 			favicon: '/favicon.svg',
 			customCss: ['./src/styles/custom.css'],
 			components: {
-				// Starlight's title slot is named SiteTitle; the file is our Logo.
 				SiteTitle: './src/components/Logo.astro',
 			},
 			head: [


### PR DESCRIPTION
Drop the deploy section, the built-with line, and the structure list (which referenced pages that no longer exist), and remove a stray comment from the Astro config.